### PR TITLE
[Bug] Buttons and images are cropped if Windows 125%, 150% and Browser 75% and lower

### DIFF
--- a/package/src/components/IconSize/IconSize.jsx
+++ b/package/src/components/IconSize/IconSize.jsx
@@ -9,6 +9,10 @@ const IconSize = styled.div`
   align-items: center;
   width: ${(props) => props.width}px;
   height: ${(props) => props.height}px;
+
+  svg {
+    overflow: visible;
+  }
 `
 
 const IconSize32 = ({ children, ...rest }) => (

--- a/package/webpack.common.js
+++ b/package/webpack.common.js
@@ -84,7 +84,24 @@ module.exports = {
       },
       {
         test: /\.svg$/i,
-        use: ['@svgr/webpack'],
+        use: [
+          {
+            loader: '@svgr/webpack',
+            options: {
+              svgoConfig: {
+                plugins: [
+                  {
+                    name: 'preset-default',
+                    params: {
+                      overrides: {
+                        removeViewBox: false
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }],
         issuer: /\.(js|ts)x?$/
       },
       {


### PR DESCRIPTION
Fixes #15 

To save the dimensions of svg untouchable we can use overflow: visible approach. Which is not allowing svg to be cropped.
I added the property for all icons inside div, seems those are the icons which are visible always, so it will not break the icons which are visible only when hovering on them.

Also I disabled default stripping viewBox from svgo, as the svgs in codebase have viewBox and there is no real benefits of stripping them, even more there are disadvantages of it (see https://github.com/svg/svgo/issues/1128)

After disabling stripping apears one more solutions to the problem:
One of advantages of the view box is that by decreasing/Increasing the width and height of the view box, we can zoom out or i in the SVG content, but it will make elements look smaller or bigger and i didn't want to change the sizes of images.
 